### PR TITLE
feat: remove the instance of $() and replace with this.element

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -167,7 +167,7 @@ export default Component.extend({
 		}
 
 		const scheduler = this.get('scheduler');
-		const element = this.$().get(0);
+		const element = this.element;
 
 		// Close modal.
 		this.set('visible', false);


### PR DESCRIPTION
- Remove dependence on jQuery
- jQuery removed in Ember 4.0, off in Octane, currently can be
 turned off